### PR TITLE
ci: persist emnapi packages in lockfile for cross-platform npm ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 22
           cache: npm
 
-      - run: npm ci
+      - run: npm ci --include=optional
       - run: npm run build
 
       - uses: peaceiris/actions-gh-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,10 @@
         "typescript": "6.0.3",
         "typescript-eslint": "8.59.2",
         "vite": "8.0.14"
+      },
+      "optionalDependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -268,6 +272,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,9 @@
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.2",
     "vite": "8.0.14"
+  },
+  "optionalDependencies": {
+    "@emnapi/core": "1.10.0",
+    "@emnapi/runtime": "1.10.0"
   }
 }


### PR DESCRIPTION
The previous deploy (PR #4) failed on `npm ci` with:

```
npm error Missing: @emnapi/core@1.10.0 from lock file
npm error Missing: @emnapi/runtime@1.10.0 from lock file
```

The previous "lockfile fix" used `npm install --include=optional`, but that flag is a session-only directive on Windows — subsequent installs on the dev machine silently dropped these platform-incompatible optional deps from the lockfile, and `npm ci` on Linux then couldn't find them.

This commit makes the fix permanent:

- Add `@emnapi/core@1.10.0` and `@emnapi/runtime@1.10.0` to `optionalDependencies` in `package.json` so they are always declared
- Manually add the corresponding `node_modules/@emnapi/core` and `node_modules/@emnapi/runtime` entries to `package-lock.json` (with `optional: true` and `engines.node >= 18`)
- Update the workflow to use `npm ci --include=optional` as a defense-in-depth measure

Verified locally: `npm ci` now installs 211 packages (was 208) and `npm run build` succeeds.

After merging, the workflow will create the `gh-pages` branch, and you can switch the Pages source in Settings to point at it.
