### PR TITLE
fix: align experience section top padding with about/projects

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -7,7 +7,7 @@ export function Experience() {
   return (
     <section id="experience" className="section-divider bg-transparent" ref={ref}>
       <div
-        className={`px-6 md:px-12 max-w-container-max mx-auto py-section-gap transition-all duration-700 ${
+        className={`px-6 md:px-12 max-w-container-max mx-auto py-24 transition-all duration-700 ${
           inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
         }`}
       >


### PR DESCRIPTION
Experience section was using `py-section-gap` (160px) while About and Projects use `py-24` (96px), causing the "03. EXPERIENCE" header to sit visibly lower than the rest of the sections when navigating via the nav bar. Now all three align.

Also brings dev up to date with main (fast-forward from `baea710` → `7bfafa8`).
