### PR TITLE
fix: change favicon to 'A' with brand orange background

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-  <rect width="48" height="48" rx="12" fill="#7c3aed"/>
-  <text x="24" y="30" text-anchor="middle" font-family="Inter, sans-serif" font-size="20" font-weight="700" fill="white">AC</text>
+  <rect width="48" height="48" rx="12" fill="#e85d10"/>
+  <text x="24" y="33" text-anchor="middle" font-family="Inter, sans-serif" font-size="28" font-weight="700" fill="white">A</text>
 </svg>


### PR DESCRIPTION
Changes:
- Favicon text: `AC` → `A` (Anupam initial)
- Background color: `#7c3aed` (Vite default purple) → `#e85d10` (brand orange)
- Slight font-size + baseline adjustment for single-letter optical balance
