### PR TITLE
fix: brighten marquee text to match about body

### DIFF
--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -4,8 +4,8 @@ export function Marquee() {
   const items = Array.from({ length: 2 }, (_, i) =>
     techStack.map((tag) => (
       <div key={`${tag}-${i}`} className="flex items-center gap-8 shrink-0">
-        <span className="text-[10px] font-bold text-primary/40">/</span>
-        <span className="text-[11px] text-on-surface/40 tracking-[0.3em] font-medium">
+        <span className="text-[10px] font-bold text-primary">/</span>
+        <span className="text-[11px] text-on-surface/70 tracking-[0.3em] font-medium">
           {tag}
         </span>
       </div>


### PR DESCRIPTION
Marquee skill names and `/` separator were using 40% opacity of the theme colors, making them visibly dimmer than the about-section body text (which uses 70% on-surface). Both are subtle UI elements that should still feel readable.

- Skill name: `text-on-surface/40` → `text-on-surface/70` (matches about body)
- Separator: `text-primary/40` → `text-primary` (full brand orange — small enough to not be loud)
