### PR TITLE
fix: about min-h fills viewport, marquee ~15% taller

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -7,7 +7,7 @@ export function About() {
   return (
     <section
       id="about"
-      className="px-6 md:px-12 max-w-container-max mx-auto py-24"
+      className="px-6 md:px-12 max-w-container-max mx-auto py-24 min-h-[calc(100vh-80px)]"
       ref={ref}
     >
       <div

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -15,7 +15,7 @@ export function Marquee() {
   return (
     <div className="border-y border-outline-variant overflow-hidden">
       <div
-        className="animate-marquee whitespace-nowrap flex gap-20 items-center py-7"
+        className="animate-marquee whitespace-nowrap flex gap-20 items-center py-8"
         style={{ width: "max-content" }}
       >
         {items}


### PR DESCRIPTION
Two adjustments:

1. **About section min-height**: added `min-h-[calc(100vh-80px)]` to About so it always fills the viewport minus the 80px navbar offset. Prevents the next section's heading from peeking through when clicking ABOUT in the nav.

2. **Marquee height**: bumped `py-7` (1.75rem, 56px total) to `py-8` (2rem, 64px total) — ~15% taller as requested.
