### PR TITLE
revert: remove min-h from About

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -7,7 +7,7 @@ export function About() {
   return (
     <section
       id="about"
-      className="px-6 md:px-12 max-w-container-max mx-auto py-24 min-h-[calc(100vh-80px)]"
+      className="px-6 md:px-12 max-w-container-max mx-auto py-24"
       ref={ref}
     >
       <div


### PR DESCRIPTION
Reverts the `min-h-[calc(100vh-80px)]` I added to About in PR #10. With it, About was forced to fill the viewport but the content (2 short paragraphs) sat at the top, leaving a huge empty gap below the content and pushing the marquee almost off-screen near the Projects heading.

Back to natural About height. Marquee sits right below the About content as before.

Kept the marquee `py-7` → `py-8` change from PR #10 (15% taller, as requested).
