### PR TITLE
style: unify section padding + add line+arrow anchor at bottom of about

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -29,6 +29,19 @@ export function About() {
           ))}
         </div>
       </div>
+      <div className="flex items-center justify-center gap-8 mt-20">
+        <span className="flex-1 max-w-32 h-px bg-on-surface/20" />
+        <svg
+          className="w-[18px] h-[18px] text-primary animate-[breathe_3s_ease-in-out_infinite]"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 9l7 7 7-7" />
+        </svg>
+        <span className="flex-1 max-w-32 h-px bg-on-surface/20" />
+      </div>
     </section>
   )
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -29,7 +29,7 @@ export function Contact() {
   return (
     <section id="contact" className="section-divider bg-surface-container-lowest" ref={ref}>
       <div
-        className={`px-6 md:px-12 max-w-container-max mx-auto flex flex-col justify-center py-20 transition-all duration-700 ${
+        className={`px-6 md:px-12 max-w-container-max mx-auto flex flex-col justify-center py-24 transition-all duration-700 ${
           inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
         }`}
       >


### PR DESCRIPTION
Two changes to fix the "About + Marquee + Projects heading" clipping on tall viewports (fullscreen, 90% zoom, large monitors):

1. **Unified section padding** — Contact changed from `py-20` → `py-24`. All 4 main sections (About, Projects, Experience, Contact) now use `py-24` for an 8pt-grid rhythm.

2. **Decorative anchor at bottom of About** — symmetrical `line — ↓ — line` design mirroring the hero's "SCROLL TO EXPLORE — line — ↓" pattern. Orange arrow with `breathe_3s` animation, lines use `bg-on-surface/20` for both themes. Adds ~80px of designed content at the bottom so the section feels complete, not empty.

The marquee is NOT moved closer to About (kept its breathing room) and the Projects heading will still peek slightly on very tall viewports, but the perceived empty space at the bottom of About is now visually anchored.

Backup plan (gradient fade on marquee) is held in reserve if the peek is still too prominent.
