### PR TITLE
style: reduce about/contact bottom padding; span line-anchor full width

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -7,7 +7,7 @@ export function About() {
   return (
     <section
       id="about"
-      className="px-6 md:px-12 max-w-container-max mx-auto py-24"
+      className="px-6 md:px-12 max-w-container-max mx-auto pt-24 pb-10"
       ref={ref}
     >
       <div
@@ -29,8 +29,8 @@ export function About() {
           ))}
         </div>
       </div>
-      <div className="flex items-center justify-center gap-8 mt-20">
-        <span className="flex-1 max-w-32 h-px bg-on-surface/20" />
+      <div className="flex items-center gap-8 mt-10">
+        <span className="flex-1 h-px bg-on-surface/20" />
         <svg
           className="w-[18px] h-[18px] text-primary animate-[breathe_3s_ease-in-out_infinite]"
           viewBox="0 0 24 24"
@@ -40,7 +40,7 @@ export function About() {
         >
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 9l7 7 7-7" />
         </svg>
-        <span className="flex-1 max-w-32 h-px bg-on-surface/20" />
+        <span className="flex-1 h-px bg-on-surface/20" />
       </div>
     </section>
   )

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -29,7 +29,7 @@ export function Contact() {
   return (
     <section id="contact" className="section-divider bg-surface-container-lowest" ref={ref}>
       <div
-        className={`px-6 md:px-12 max-w-container-max mx-auto flex flex-col justify-center py-24 transition-all duration-700 ${
+        className={`px-6 md:px-12 max-w-container-max mx-auto flex flex-col justify-center pt-24 pb-10 transition-all duration-700 ${
           inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
         }`}
       >


### PR DESCRIPTION
Reduces bottom padding of About and Contact (py-24 -> pt-24 pb-10) to prevent marquee/footer being cut on tall viewports. Restructures the bottom line-anchor in About to span the full section width so the left line starts at the title's left edge and the right line ends at the description's right edge, with the chevron centered between them.